### PR TITLE
Aligning with draft-dhody-pce-pceps-tls13

### DIFF
--- a/draft-ietf-netconf-over-tls13.md
+++ b/draft-ietf-netconf-over-tls13.md
@@ -80,19 +80,20 @@ data. In particular, early data is not forward secret, and there are no
 protection against the replay of early data between connections.
 {{Appendix E.5 of I-D.ietf-tls-rfc8446bis}} requires applicaitons not
 use early data without a profile that defines its use. This document
-specifies that implementations that support TLS 1.3 MUST NOT use early data.
+specifies that NETCONF implementations that support TLS 1.3 MUST NOT use early
+data.
 
 # Cipher Suites
 
-Implementations MUST support TLS 1.3 {{I-D.ietf-tls-rfc8446bis}}, and
-implementation are REQUIRED to support the mandatory-to-implement cipher
-suites listed in {{Section 9.1 of I-D.ietf-tls-rfc8446bis}}.
+Implementations that support TLS 1.3 {{I-D.ietf-tls-rfc8446bis}} are REQUIRED
+to support the mandatory-to-implement cipher suites listed in
+{{Section 9.1 of I-D.ietf-tls-rfc8446bis}}.
 
-Implementations MAY implement additional TLS cipher suites that provide
-mutual authentication and confidentiality, which are required for NETCONF
-{{RFC6241}}.
+Implementations that support TLS 1.3 MAY implement additional TLS cipher
+suites that provide mutual authentication and confidentiality, which are
+required for NETCONF {{RFC6241}}.
 
-Implementations SHOULD follow the recommendations given in
+NETCONF implementations SHOULD follow the recommendations given in
 {{!I-D.ietf-uta-rfc7525bis}}.
 
 ~~~

--- a/draft-ietf-netconf-over-tls13.md
+++ b/draft-ietf-netconf-over-tls13.md
@@ -67,9 +67,11 @@ identity.
 
 Early data (aka 0-RTT data) is a mechanism defined in TLS 1.3
 {{I-D.ietf-tls-rfc8446bis}} that allows a client to send data ("early data")
-as part of the first flight of messages to a server. Early data is
-permitted by TLS 1.3 when the client and server share a PSK, either obtained
-externally or via a previous handshake. The client uses the PSK to
+as part of the first flight of messages to a server. Note that TLS 1.3 can
+be used without early data early data as per
+{{Section F.5 of I-D.ietf-tls-rfc8446bis}}. In fact, early data is permitted
+by TLS 1.3 only when the client and server share a Pre-Shared Key (PSK),
+either obtained externally or via a previous handshake. The client uses the PSK to
 authenticate the server and to encrypt the early data.
 
 As noted in {{Section 2.3 of I-D.ietf-tls-rfc8446bis}}, the security
@@ -78,7 +80,7 @@ data. In particular, early data is not forward secret, and there are no
 protection against the replay of early data between connections.
 {{Appendix E.5 of I-D.ietf-tls-rfc8446bis}} requires applicaitons not
 use early data without a profile that defines its use. This document
-specifies that implementations MUST NOT use early data.
+specifies that implementations that support TLS 1.3 MUST NOT use early data.
 
 # Cipher Suites
 


### PR DESCRIPTION
[Dhruv](https://datatracker.ietf.org/person/Dhruv%20Dhody) noted the [PCEPS](https://datatracker.ietf.org/doc/rfc5440/) need the same kind of document. He created what essentially was fork. During PCE's consideration of the I-D, Adrian [noted](https://mailarchive.ietf.org/arch/msg/pce/q0H6u9kytU6-D-VrHdz1F_omgRw/) that some minor wording tweaks would clarify that the intention is to describe what NETCONF implementations that support TLS 1.3 are supposed to do, and that doesn't have any knock-on for other work.

Since the I-Ds are doing the same thing just for different protocols, I figured I'd avoid an IESG comment/discuss by just aligning the two I-Ds.